### PR TITLE
Atualiza agendamento para combos sem constantes DUO

### DIFF
--- a/lib/booking_constants.php
+++ b/lib/booking_constants.php
@@ -1,8 +1,0 @@
-<?php
-// Constantes compartilhadas referentes ao combo de dois tratamentos
-if (!defined('DUO_SERVICE_ID')) {
-    define('DUO_SERVICE_ID', 10);
-}
-if (!defined('DUO_PRECO')) {
-    define('DUO_PRECO', 260.00);
-}

--- a/lib/booking_helpers.php
+++ b/lib/booking_helpers.php
@@ -1,16 +1,4 @@
 <?php
-$bookingConstantsPath = __DIR__ . '/booking_constants.php';
-if (file_exists($bookingConstantsPath)) {
-    require_once $bookingConstantsPath;
-} else {
-    if (!defined('DUO_SERVICE_ID')) {
-        define('DUO_SERVICE_ID', 10);
-    }
-    if (!defined('DUO_PRECO')) {
-        define('DUO_PRECO', 260.00);
-    }
-}
-
 /**
  * Retorna um mapa id => nome das especialidades, com cache simples para a requisição.
  */
@@ -32,26 +20,23 @@ function obterMapaEspecialidades(mysqli $conn): array {
 }
 
 /**
- * Monta o nome exibido para serviços selecionados, tratando o combo de dois tratamentos.
+ * Monta o nome exibido para serviços selecionados, priorizando os IDs presentes em servicos_csv
+ * quando houver. Caso contrário, utiliza o nome informado como fallback.
  *
  * @return array{0:string,1:array<int,string>} [titulo, lista de nomes]
  */
 function descreverServicos(mysqli $conn, int $especialidadeId, ?string $servicosCsv, string $fallbackNome): array {
     $nomes = [];
 
-    if ($especialidadeId === DUO_SERVICE_ID && $servicosCsv) {
-        $ids = array_values(array_filter(array_map('intval', explode(',', $servicosCsv))));
+    if ($servicosCsv) {
+        $ids = array_values(array_unique(array_filter(array_map('intval', explode(',', $servicosCsv)))));
         if ($ids) {
             $mapa = obterMapaEspecialidades($conn);
             foreach ($ids as $id) {
-                if ($id === DUO_SERVICE_ID) {
-                    continue;
-                }
                 if (isset($mapa[$id])) {
                     $nomes[] = $mapa[$id];
                 }
             }
-            $nomes = array_values(array_unique($nomes));
         }
     }
 


### PR DESCRIPTION
## Summary
- Atualiza o front-end de agendamento para calcular valores a partir da duração selecionada e sempre enviar o primeiro serviço como principal, apenas incluindo a lista CSV quando houver dois tratamentos.
- Refatora o back-end de agendar.php para validar no máximo dois serviços, garantir consistência entre servico_id e servicos_csv e calcular o preço oficial usando a mesma lógica para um ou dois tratamentos.
- Simplifica os helpers removendo as constantes DUO e descrevendo combos diretamente a partir do CSV armazenado.

## Testing
- php -l agendamento.php
- php -l agendar.php
- php -l lib/booking_helpers.php

------
https://chatgpt.com/codex/tasks/task_e_68ddf333f0988329ad654b2514d02ce2