### PR TITLE
Corrige seleção de serviço para combinações com Quick Massage

### DIFF
--- a/agendamento.php
+++ b/agendamento.php
@@ -1032,6 +1032,51 @@ if ($res instanceof mysqli_result) {
         .filter(Boolean)
         .slice(0, 2);
     }
+
+    function obterNomeServicoPorId(id) {
+      if (!id) {
+        return '';
+      }
+
+      const card = document.querySelector(`.treatment[data-id="${id}"]`);
+      if (!card) {
+        return '';
+      }
+
+      const rotulo = card.querySelector('span');
+      return rotulo ? rotulo.textContent.trim().toLowerCase() : '';
+    }
+
+    function determinarServicoPrincipal(ids, duracaoSelecionada) {
+      if (!Array.isArray(ids) || ids.length === 0) {
+        return '';
+      }
+
+      if (ids.length === 1) {
+        return ids[0];
+      }
+
+      const duracao = String(duracaoSelecionada || '').trim();
+      const duracoesQuick = new Set(['15', '30']);
+      const duracoesNaoQuick = new Set(['50', '90', 'pacote5', 'pacote10']);
+
+      const quickId = ids.find(id => obterNomeServicoPorId(id) === 'quick massage');
+      const naoQuickId = ids.find(id => obterNomeServicoPorId(id) !== 'quick massage');
+
+      if (duracoesQuick.has(duracao) && quickId) {
+        return quickId;
+      }
+
+      if (duracoesNaoQuick.has(duracao) && naoQuickId) {
+        return naoQuickId;
+      }
+
+      if (!duracao && naoQuickId) {
+        return naoQuickId;
+      }
+
+      return quickId || naoQuickId || ids[0];
+    }
     const avisoTratamentoToast = (() => {
       let toast = document.getElementById('aviso-tratamento-toast');
       if (!toast) {
@@ -1136,7 +1181,7 @@ if ($res instanceof mysqli_result) {
         hora: horaSelecionada
       };
 
-      const servicoPrincipal = servicosSelecionados[0];
+      const servicoPrincipal = determinarServicoPrincipal(servicosSelecionados, duracaoSelecionada.value);
       dados.servico_id = String(servicoPrincipal);
       dados.duracao = duracaoSelecionada.value;
 

--- a/tests/manual/quick_combo.md
+++ b/tests/manual/quick_combo.md
@@ -1,0 +1,19 @@
+# Teste manual: Quick Massage combinada com outro tratamento
+
+## Pré-requisitos
+- A tabela `especialidades` deve conter pelo menos os serviços "Quick Massage" (id esperado: 1) e um tratamento padrão como "Massoterapia" (id esperado: 2) com preços preenchidos para 50 e 90 minutos.
+- Ter acesso ao painel de rede do navegador ou ao banco de dados para confirmar o preço gravado.
+
+## Passos
+1. Acesse `agendamento.php` no navegador.
+2. Selecione **Quick Massage** e outro tratamento com duração padrão (ex.: Massoterapia), garantindo que ambos os cartões fiquem destacados.
+3. Escolha a duração de **50 minutos** (repita o teste com 90 minutos, se desejar) e mantenha o escalda pés desmarcado.
+4. Preencha os dados obrigatórios (use um e-mail de teste) e conclua o agendamento.
+5. No painel de rede do navegador, inspecione a requisição `agendar.php`:
+   - Confirme que o payload envia `servico_id` correspondente ao tratamento não-Quick (ex.: `2` para Massoterapia).
+6. Verifique o valor armazenado:
+   - Consulte o registro gravado (via banco ou resposta da API) e confirme que o campo de preço coincide com `preco_50` (ou `preco_90`) do tratamento não-Quick selecionado.
+
+## Resultado esperado
+- Quando Quick Massage é combinada com outro tratamento e uma duração de 50/90 minutos é escolhida, o backend utiliza o `servico_id` do tratamento padrão e grava o preço respectivo (`preco_50` ou `preco_90`) desse tratamento.
+- O campo CSV (`servicos` no payload / `servicos_csv` no banco) mantém ambos os IDs para histórico.


### PR DESCRIPTION
## Summary
- atualiza o agendamento web para escolher o serviço compatível com a duração quando há dois tratamentos selecionados
- recalcula o serviço no back-end com base nos preços disponíveis para a duração escolhida e mantém o CSV de históricos
- documenta um teste manual cobrindo a combinação de Quick Massage com outro tratamento

## Testing
- php -l agendar.php
- php -l agendamento.php

------
https://chatgpt.com/codex/tasks/task_e_68ddf8864edc8329a2f69de52c550144