### PR TITLE
Aumenta tamanho e adiciona sombra ao logo da tela de registro

### DIFF
--- a/registrar.html
+++ b/registrar.html
@@ -53,10 +53,11 @@
     }
     .logo {
       text-align: center;
-      margin-bottom: 9px;
+      margin-bottom: 6px;
     }
     .logo img {
-      height: 54px;
+      height: 80px;
+      filter: drop-shadow(0 4px 6px rgba(0,0,0,0.2));
     }
     .titulo-principal {
       text-align: center;
@@ -172,6 +173,9 @@
       .login-registro-container {
         max-width: 98vw;
         padding: 17px 3vw 20px 3vw;
+      }
+      .logo img {
+        height: 64px;
       }
       .titulo-principal {
         font-size: 1.27rem;


### PR DESCRIPTION
## Summary
- aumenta a altura da imagem do logotipo na página de registro e aplica efeito de sombra suave
- ajusta o espaçamento inferior do bloco do logotipo para manter o alinhamento do conteúdo
- define uma altura reduzida para o logotipo em telas pequenas para preservar a responsividade

## Testing
- não aplicável

------
https://chatgpt.com/codex/tasks/task_e_68ded241b6148329aa573648868246bf