### PR TITLE
Ajusta navegação do calendário em telas pequenas

### DIFF
--- a/admin/agenda.php
+++ b/admin/agenda.php
@@ -828,15 +828,20 @@ foreach ($agendamentos as $a) {
       }
 
       .calendar-nav {
-        gap: 8px;
+        justify-content: center;
+        gap: 6px;
+        flex-wrap: nowrap;
       }
 
       .calendar-nav button {
-        flex: 1 1 46px;
+        flex: 0 0 auto;
+        min-width: 34px;
+        padding: 0.35rem;
       }
 
       .calendar-nav-label {
-        flex: 1 1 100%;
+        flex: 0 0 auto;
+        margin: 0 8px;
         text-align: center;
         font-size: 1.1rem;
       }


### PR DESCRIPTION
## Summary
- centraliza os controles de navegação do calendário em telas de até 520px
- compacta os botões usando o espaçamento da variante de ícone e evita que o rótulo ocupe toda a largura

## Testing
- ⚠️ `Manual QA` *(falhou por dependência ausente: ../conexao.php durante o carregamento de admin/agenda.php)*

------
https://chatgpt.com/codex/tasks/task_e_68defd5b6490832993986d53cc83d48a