### PR TITLE
Fix FullCalendar configuration in admin agenda

### DIFF
--- a/admin/agenda.php
+++ b/admin/agenda.php
@@ -1586,6 +1586,7 @@ foreach ($agendamentosCalendario as $a) {
       setupStatusActionHandlers();
 
       const calendar = new FullCalendar.Calendar(calendarEl, {
+        plugins: [FullCalendar.dayGridPlugin, FullCalendar.interactionPlugin],
         initialView: 'dayGridMonth',
         locale: 'pt-br',
         height: 600,
@@ -1717,20 +1718,6 @@ function abrirBloquearHorario(data, hora) {
   };
 }
 
-
- document.addEventListener('DOMContentLoaded', function() {
-  var calendarEl = document.getElementById('calendar-admin');
-              var calendar = new FullCalendar.Calendar(calendarEl, {
-                initialView: 'dayGridMonth',
-              locale: 'pt-br',
-              height: 600,
-              events: <?php echo json_encode($eventos_calendario); ?>,
-              dateClick: function(info) {
-                mostrarModalOpcoes(info.dateStr);
-    }
-  });
-              calendar.render();
-});
 
  </script>
  <script>


### PR DESCRIPTION
## Summary
- enable FullCalendar dayGrid and interaction plugins for the admin agenda calendar
- remove the duplicate calendar initialization that caused conflicting renders

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df2fff9a588329a8de76f33ecb1e87