### PR TITLE
Fix FullCalendar global bundle integration

### DIFF
--- a/admin/agenda.php
+++ b/admin/agenda.php
@@ -1321,7 +1321,7 @@ foreach ($agendamentosCalendario as $a) {
   <title>Agenda Unificada</title>
 
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.10/index.global.min.css">
-  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.10/index.global.min.js"></script>
 
 </head>
 
@@ -1586,7 +1586,7 @@ foreach ($agendamentosCalendario as $a) {
       setupStatusActionHandlers();
 
       const calendar = new FullCalendar.Calendar(calendarEl, {
-        plugins: [FullCalendar.dayGridPlugin, FullCalendar.interactionPlugin],
+        plugins: [FullCalendarDayGrid, FullCalendarInteraction],
         initialView: 'dayGridMonth',
         locale: 'pt-br',
         height: 600,


### PR DESCRIPTION
## Summary
- align FullCalendar CSS and JS assets to the same global bundle version
- update calendar initialization to use the global bundle plugin identifiers

## Testing
- not run (environment only provides static analysis)


------
https://chatgpt.com/codex/tasks/task_e_68df38c0c6e0832996758bb40b64d2c6