### PR TITLE
Padroniza status de indisponibilidade e destaca bloqueios no calendário

### DIFF
--- a/admin/agendarFixo.php
+++ b/admin/agendarFixo.php
@@ -57,7 +57,7 @@ for ($i = 0; $i < $repeticoes; $i++) {
 $agendados = 0;
 foreach ($datasGeradas as $dataOcorrencia) {
     $data_horario = $dataOcorrencia->format('Y-m-d') . ' ' . $horaFormatada;
-    $stmt = $conn->prepare("SELECT COUNT(*) as qtd FROM agendamentos WHERE data_horario = ? AND status IN ('Confirmado','Indisponível')");
+    $stmt = $conn->prepare("SELECT COUNT(*) as qtd FROM agendamentos WHERE data_horario = ? AND status IN ('Confirmado','Indisponivel')");
     $stmt->bind_param('s', $data_horario);
     $stmt->execute();
     $r = $stmt->get_result()->fetch_assoc();

--- a/admin/bloquearHorario.php
+++ b/admin/bloquearHorario.php
@@ -6,7 +6,7 @@ if (!isset($_SESSION['usuario_id']) || $_SESSION['tipo'] !== 'terapeuta') {
 require_once '../conexao.php';
 $data = $_POST['data_horario'] ?? '';
 if ($data) {
-    $stmt = $conn->prepare("INSERT INTO agendamentos (data_horario, status, duracao) VALUES (?, 'Indisponível', 60)");
+    $stmt = $conn->prepare("INSERT INTO agendamentos (data_horario, status, duracao) VALUES (?, 'Indisponivel', 60)");
     $stmt->bind_param('s', $data);
     $stmt->execute();
 }

--- a/admin/getEventosAgenda.php
+++ b/admin/getEventosAgenda.php
@@ -9,7 +9,7 @@ $eventos = [];
 $sql = "SELECT a.id, a.data_horario, a.status, a.usuario_id, u.nome as paciente
         FROM agendamentos a
         LEFT JOIN usuarios u ON a.usuario_id = u.id
-        WHERE a.status IN ('Confirmado','Concluido','Indisponível')";
+        WHERE a.status IN ('Confirmado','Concluido','Indisponivel')";
 $res = $conn->query($sql);
 
 while ($row = $res->fetch_assoc()) {


### PR DESCRIPTION
## Summary
- padroniza o status de bloqueio para "Indisponivel" em todos os fluxos de criação e consulta
- inclui eventos de indisponibilidade no calendário com visual diferenciado e bloqueio agregado por dia
- sinaliza domingos e datas bloqueadas visualmente no FullCalendar e impede interações nesses dias

## Testing
- php -l admin/agenda.php
- php -l admin/agendarFixo.php
- php -l admin/bloquearHorario.php
- php -l admin/getEventosAgenda.php

------
https://chatgpt.com/codex/tasks/task_e_68df3dd31f3c8329bfa1a4fa68d3699b