### PR TITLE
Add visitor support to fixed scheduling modal

### DIFF
--- a/admin/agenda.php
+++ b/admin/agenda.php
@@ -2131,12 +2131,37 @@ function abrirAgendamentoFixo(data, hora) {
   document.getElementById('modal-title').innerText = 'Agendamento Fixo';
   const modalBody = document.getElementById('modal-body');
   modalBody.innerHTML = `
-        <form method="post" action="agendarFixo.php" autocomplete="off">
-          <label>Usuário:
-            <input type="text" id="usuario_nome_fixo" placeholder="Digite o nome..." autocomplete="off" required>
-            <input type="hidden" name="usuario_id" id="usuario_id_fixo" required>
-            <div id="autocomplete-list-fixo" class="autocomplete-items"></div>
-          </label>
+        <form id="form-agendamento-fixo" method="post" action="agendarFixo.php" autocomplete="off">
+          <input type="hidden" name="visitante" id="agendamento-fixo-visitante-flag" value="0">
+          <div id="agendamento-fixo-usuario">
+            <label>Usuário:
+              <input type="text" id="usuario_nome_fixo" placeholder="Digite o nome..." autocomplete="off">
+              <input type="hidden" name="usuario_id" id="usuario_id_fixo">
+              <div id="autocomplete-list-fixo" class="autocomplete-items"></div>
+            </label>
+            <button type="button" id="btn-fixo-para-visitante" class="calendar-btn calendar-btn--secondary">Agendar para visitante</button>
+          </div>
+          <div id="agendamento-fixo-visitante" style="display:none;">
+            <div class="guest-form">
+              <label for="guest-name-fixo">Nome</label>
+              <input type="text" id="guest-name-fixo" name="guest_name">
+              <label for="guest-email-fixo">E-mail</label>
+              <input type="email" id="guest-email-fixo" name="guest_email">
+              <label for="guest-phone-fixo">Número de telefone</label>
+              <input type="tel" id="guest-phone-fixo" name="guest_phone" placeholder="+55" pattern="\\+?\\d{2,15}">
+              <label for="guest-nascimento-fixo">Data de nascimento</label>
+              <input type="date" id="guest-nascimento-fixo" name="guest_nascimento">
+              <label for="guest-sexo-fixo">Sexo</label>
+              <select id="guest-sexo-fixo" name="guest_sexo">
+                <option value="">Selecione...</option>
+                <option value="feminino">Feminino</option>
+                <option value="masculino">Masculino</option>
+                <option value="outro">Outro</option>
+                <option value="prefiro_nao_dizer">Prefiro não dizer</option>
+              </select>
+            </div>
+            <button type="button" id="btn-fixo-voltar-usuario" class="calendar-btn calendar-btn--ghost">Selecionar usuário cadastrado</button>
+          </div>
           <label>Especialidade:
             <select name="especialidade_id" required>
               <option value="1">Quick Massage</option>
@@ -2172,6 +2197,9 @@ function abrirAgendamentoFixo(data, hora) {
           <label>Repetições:
             <input type="number" name="repeticoes" value="1" min="1" required>
           </label>
+          <label class="checkbox-inline">
+            <input type="checkbox" name="adicional_reflexo_fixo" value="1"> Adicional Escalda
+          </label>
           <div class="calendar-modal-actions">
             <button type="submit" class="calendar-btn calendar-btn--primary">Agendar Fixo</button>
             <button type="button" class="calendar-btn calendar-btn--secondary" onclick="mostrarModalOpcoes('${data}')">Voltar</button>
@@ -2179,6 +2207,7 @@ function abrirAgendamentoFixo(data, hora) {
         </form>
       `;
   setupAutocomplete('usuario_nome_fixo', 'usuario_id_fixo', 'autocomplete-list-fixo');
+
   const diaSemanaSelect = modalBody.querySelector('select[name="dia_semana"]');
   if (diaSemanaSelect) {
     const baseDate = new Date(`${data}T00:00:00`);
@@ -2188,10 +2217,74 @@ function abrirAgendamentoFixo(data, hora) {
       diaSemanaSelect.value = String(diaSemana);
     }
   }
+
   const horarioInput = modalBody.querySelector('input[name="horario"]');
   if (horarioInput && hora) {
     horarioInput.value = hora.substring(0, 5);
   }
+
+  const usuarioNomeInput = modalBody.querySelector('#usuario_nome_fixo');
+  const usuarioIdInput = modalBody.querySelector('#usuario_id_fixo');
+  const visitanteFlag = modalBody.querySelector('#agendamento-fixo-visitante-flag');
+  const usuarioSection = modalBody.querySelector('#agendamento-fixo-usuario');
+  const visitanteSection = modalBody.querySelector('#agendamento-fixo-visitante');
+  const btnParaVisitante = modalBody.querySelector('#btn-fixo-para-visitante');
+  const btnVoltarUsuario = modalBody.querySelector('#btn-fixo-voltar-usuario');
+  const visitanteCampos = visitanteSection ? visitanteSection.querySelectorAll('input, select') : [];
+
+  function atualizarModoVisitante(ativar) {
+    if (!usuarioSection || !visitanteSection || !visitanteFlag) {
+      return;
+    }
+
+    visitanteFlag.value = ativar ? '1' : '0';
+    usuarioSection.style.display = ativar ? 'none' : '';
+    visitanteSection.style.display = ativar ? '' : 'none';
+
+    if (usuarioNomeInput) {
+      usuarioNomeInput.required = !ativar;
+      if (ativar) {
+        usuarioNomeInput.value = '';
+      }
+    }
+
+    if (usuarioIdInput) {
+      usuarioIdInput.required = !ativar;
+      if (ativar) {
+        usuarioIdInput.value = '';
+      }
+    }
+
+    const camposObrigatorios = ['guest_name', 'guest_email', 'guest_phone'];
+    visitanteCampos.forEach((campo) => {
+      if (!(campo instanceof HTMLElement)) {
+        return;
+      }
+
+      if (ativar) {
+        campo.required = camposObrigatorios.includes(campo.name);
+      } else {
+        campo.required = false;
+        if ('value' in campo) {
+          campo.value = '';
+        }
+      }
+    });
+  }
+
+  if (btnParaVisitante) {
+    btnParaVisitante.addEventListener('click', function () {
+      atualizarModoVisitante(true);
+    });
+  }
+
+  if (btnVoltarUsuario) {
+    btnVoltarUsuario.addEventListener('click', function () {
+      atualizarModoVisitante(false);
+    });
+  }
+
+  atualizarModoVisitante(false);
 }
 
 

--- a/admin/agendarFixo.php
+++ b/admin/agendarFixo.php
@@ -7,16 +7,41 @@ if (!isset($_SESSION['usuario_id']) || $_SESSION['tipo'] !== 'terapeuta') {
 require_once '../conexao.php';
 
 // Parâmetros recebidos do form
-$usuario_id = intval($_POST['usuario_id'] ?? 0); // paciente
+$visitante = isset($_POST['visitante']) && $_POST['visitante'] === '1';
+$usuario_id = $visitante ? 0 : intval($_POST['usuario_id'] ?? 0); // paciente
 $data_inicio = $_POST['data_inicio'] ?? '';
 $horario     = $_POST['horario'] ?? '';
 $dia_semana  = intval($_POST['dia_semana'] ?? 0); // 1=segunda ... 7=domingo
 $duracao     = intval($_POST['duracao'] ?? 60);
 $especialidade_id = intval($_POST['especialidade_id'] ?? 1); // ajuste conforme seu sistema
 $repeticoes = intval($_POST['repeticoes'] ?? 0);
+$adicional_reflexo = isset($_POST['adicional_reflexo_fixo']) ? 1 : 0;
+
+$guest_name = trim($_POST['guest_name'] ?? '');
+$guest_email = trim($_POST['guest_email'] ?? '');
+$guest_phone = trim($_POST['guest_phone'] ?? '');
+$guest_nascimento = trim($_POST['guest_nascimento'] ?? '');
+$idade_visitante = null;
+
+if ($visitante) {
+    if ($guest_name === '' || $guest_email === '' || $guest_phone === '') {
+        header('Location: agenda.php?msg=erro_visitante'); exit;
+    }
+    if (!filter_var($guest_email, FILTER_VALIDATE_EMAIL)) {
+        header('Location: agenda.php?msg=email_invalido'); exit;
+    }
+    if ($guest_nascimento !== '') {
+        $dtNascimento = DateTime::createFromFormat('Y-m-d', $guest_nascimento);
+        if (!$dtNascimento || $dtNascimento->format('Y-m-d') !== $guest_nascimento) {
+            header('Location: agenda.php?msg=data_invalida'); exit;
+        }
+        $idade_visitante = $dtNascimento->diff(new DateTime('now'))->y;
+    }
+} elseif (!$usuario_id) {
+    header('Location: agenda.php?msg=erro_param'); exit;
+}
 
 if (
-    !$usuario_id ||
     !$data_inicio ||
     !$horario ||
     !$dia_semana ||
@@ -57,7 +82,7 @@ for ($i = 0; $i < $repeticoes; $i++) {
 $agendados = 0;
 foreach ($datasGeradas as $dataOcorrencia) {
     $data_horario = $dataOcorrencia->format('Y-m-d') . ' ' . $horaFormatada;
-    $stmt = $conn->prepare("SELECT COUNT(*) as qtd FROM agendamentos WHERE data_horario = ? AND status IN ('Confirmado','Indisponivel')");
+    $stmt = $conn->prepare("SELECT COUNT(*) as qtd FROM agendamentos WHERE data_horario = ? AND status IN ('Confirmado','Indisponivel','Indisponível')");
     $stmt->bind_param('s', $data_horario);
     $stmt->execute();
     $r = $stmt->get_result()->fetch_assoc();
@@ -67,8 +92,14 @@ foreach ($datasGeradas as $dataOcorrencia) {
         continue;
     }
 
-    $stmt2 = $conn->prepare("INSERT INTO agendamentos (usuario_id, especialidade_id, data_horario, duracao, status, criado_em) VALUES (?, ?, ?, ?, 'Confirmado', NOW())");
-    $stmt2->bind_param('iisi', $usuario_id, $especialidade_id, $data_horario, $duracao);
+    if ($visitante) {
+        $stmt2 = $conn->prepare("INSERT INTO agendamentos (usuario_id, nome_visitante, email_visitante, telefone_visitante, idade_visitante, especialidade_id, data_horario, duracao, adicional_reflexo, status, criado_em) VALUES (NULL, ?, ?, ?, ?, ?, ?, ?, ?, 'Confirmado', NOW())");
+        $stmt2->bind_param('sssiisii', $guest_name, $guest_email, $guest_phone, $idade_visitante, $especialidade_id, $data_horario, $duracao, $adicional_reflexo);
+    } else {
+        $stmt2 = $conn->prepare("INSERT INTO agendamentos (usuario_id, especialidade_id, data_horario, duracao, adicional_reflexo, status, criado_em) VALUES (?, ?, ?, ?, ?, 'Confirmado', NOW())");
+        $stmt2->bind_param('iisii', $usuario_id, $especialidade_id, $data_horario, $duracao, $adicional_reflexo);
+    }
+
     $stmt2->execute();
     $stmt2->close();
     $agendados++;


### PR DESCRIPTION
## Summary
- add visitor toggle and escalda option to the fixed scheduling modal in the admin agenda
- update agendarFixo.php to accept visitor data, validate inputs, and persist the additional reflexology flag
- ensure blocked dates consider both spellings of "Indisponível" during fixed booking generation

## Testing
- php -l admin/agenda.php
- php -l admin/agendarFixo.php

------
https://chatgpt.com/codex/tasks/task_e_68ded7e80120832991d010aa773f2b54