### PR TITLE
Add guard clause when FullCalendar CDN is unavailable

### DIFF
--- a/admin/agenda.php
+++ b/admin/agenda.php
@@ -2020,9 +2020,19 @@ if (!empty($eventos_bloqueados)) {
 
       setupStatusActionHandlers();
 
-      const calendarPlugins = window.FullCalendar
-        ? [FullCalendar.dayGridPlugin, FullCalendar.interactionPlugin].filter(Boolean)
-        : [];
+      if (!window.FullCalendar || !FullCalendar.Calendar) {
+        const aviso = document.createElement('div');
+        aviso.className = 'alert alert-warning mt-3';
+        aviso.textContent = 'Não foi possível carregar o calendário no momento. Por favor, verifique sua conexão e tente novamente mais tarde.';
+        calendarEl.innerHTML = '';
+        calendarEl.appendChild(aviso);
+        return;
+      }
+
+      const calendarPlugins = [
+        FullCalendar.dayGridPlugin,
+        FullCalendar.interactionPlugin
+      ].filter(Boolean);
 
       const calendarConfig = {
         initialView: 'dayGridMonth',


### PR DESCRIPTION
## Summary
- add a guard clause before creating the FullCalendar instance so the admin agenda shows a friendly warning if the library failed to load
- only resolve the calendar plugins and instantiate FullCalendar after confirming the CDN assets are available

## Testing
- node <<'NODE' ... (simulate missing FullCalendar to verify the warning banner is rendered)

------
https://chatgpt.com/codex/tasks/task_e_68e4c051aa3483299195125e32338fb8