### PR TITLE
Expose scheduling helpers globally

### DIFF
--- a/admin/agenda.php
+++ b/admin/agenda.php
@@ -2156,6 +2156,8 @@ if (!empty($eventos_bloqueados)) {
   `;
     }
 
+    window.abrirOpcoesHorario = abrirOpcoesHorario;
+
     // Bloquear dia inteiro
     function abrirBloquearDia(data) {
       document.getElementById('modal-title').innerText = 'Bloquear Dia Inteiro ' + data.split('-').reverse().join('/');
@@ -2664,6 +2666,8 @@ function abrirAgendamentoNovo(data, hora) {
 
   atualizarModoVisitante(false);
 }
+
+window.abrirAgendamentoNovo = abrirAgendamentoNovo;
 
 
     </script>


### PR DESCRIPTION
## Summary
- expose the inline-invoked scheduling helpers on the window object in the admin agenda view

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e539b49ea08329b01ab5b75f428d1d