### PR TITLE
Fix FullCalendar stylesheet reference on admin agenda page

### DIFF
--- a/admin/agenda.php
+++ b/admin/agenda.php
@@ -1732,7 +1732,7 @@ if (!empty($eventos_bloqueados)) {
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Agenda Unificada</title>
 
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.10/main.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.10/index.global.min.css">
   <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.10/index.global.min.js"></script>
 
 </head>


### PR DESCRIPTION
## Summary
- switch the agenda page to load FullCalendar's `index.global.min.css` so it matches the global bundle already in use

## Testing
- `curl -I -H "User-Agent: Mozilla/5.0" https://cdn.jsdelivr.net/npm/fullcalendar@6.1.10/index.global.min.css` *(fails with 403 due to environment CDN restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e5ed0eecd083299b6eb915be8e89f7