### PR TITLE
Alinha cabeçalho responsivo nas páginas de administração

### DIFF
--- a/admin/blog.php
+++ b/admin/blog.php
@@ -108,7 +108,7 @@ function categoria_sel($cat, $valor) {
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
     <style>
         body { background: #f8faf4; }
-        .container { max-width:800px; margin:34px auto 50px auto; background:#fff; border-radius:15px; box-shadow:0 3px 24px #b7b7b752; padding:38px 30px 30px 30px; }
+        .container { max-width:800px; margin:94px auto 50px auto; background:#fff; border-radius:15px; box-shadow:0 3px 24px #b7b7b752; padding:38px 30px 30px 30px; }
         h1 { color:#496a4c; text-align:center; }
         .msg-ok { background:#d0f0e0; color:#2c7650; padding:10px 0; border-radius:7px; text-align:center; font-weight:600; margin-bottom:22px; }
         form input, form select, form textarea { width:100%; margin:6px 0 16px 0; padding:7px 9px; border-radius:7px; border:1px solid #bbb6a6; font-size:1em; }
@@ -128,23 +128,150 @@ function categoria_sel($cat, $valor) {
         .btn-edit:hover { background:#eb9800; }
         .btn-toggle.pub:hover { background:#247a3c; }
         .btn-toggle.despub:hover { background:#931e16; }
-        @media(max-width:700px){ .container{padding:10px;} .table-posts th, .table-posts td{font-size:0.98em;} }
-        .header-admin { position: fixed; top: 0; left: 0; right: 0; height: 63px; display: flex; align-items: center; justify-content: space-between; background: #256d54; color: #fff; font-family: 'Playfair Display', serif; font-size: 1.27rem; box-shadow: 0 6px 30px #256d5412, 0 2px 10px #1d9a7718; z-index: 999; padding: 0 4vw; }
-        .header-admin .menu-horizontal { display: flex; gap: 14px; }
-        .header-admin .menu-btn { background: none; border: none; color: #fff; font-size: 1.09rem; font-weight: 600; padding: 8px 17px 7px 17px; border-radius: 12px; transition: background .17s, color .14s; cursor: pointer; text-decoration: none; outline: none; display: inline-block; }
-        .header-admin .menu-btn.active, .header-admin .menu-btn:hover { background: #ffd972; color: #256d54; }
+        .header-admin {
+          position: fixed;
+          top: 0;
+          left: 0;
+          right: 0;
+          height: 63px;
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          background: #256d54;
+          color: #fff;
+          font-family: 'Playfair Display', serif;
+          font-size: 1.27rem;
+          box-shadow: 0 6px 30px #256d5412, 0 2px 10px #1d9a7718;
+          z-index: 999;
+          padding: 0 4vw;
+          gap: 16px;
+        }
+
+        .header-admin .header-brand {
+          font-weight: 700;
+          letter-spacing: .4px;
+        }
+
+        .header-admin .menu-container {
+          display: flex;
+          align-items: center;
+        }
+
+        .header-admin .menu-horizontal {
+          display: flex;
+          gap: 14px;
+        }
+
+        .header-admin .menu-toggle {
+          display: none;
+          background: none;
+          border: none;
+          color: #fff;
+          font-size: 1.7rem;
+          cursor: pointer;
+          line-height: 1;
+          padding: 6px 10px;
+          border-radius: 10px;
+          transition: background .17s;
+        }
+
+        .header-admin .menu-toggle:hover,
+        .header-admin.is-open .menu-toggle {
+          background: rgba(255, 255, 255, 0.12);
+        }
+
+        .header-admin .menu-btn {
+          background: none;
+          border: none;
+          color: #fff;
+          font-size: 1.09rem;
+          font-weight: 600;
+          padding: 8px 17px 7px 17px;
+          border-radius: 12px;
+          transition: background .17s, color .14s;
+          cursor: pointer;
+          text-decoration: none;
+          outline: none;
+          display: inline-block;
+        }
+
+        .header-admin .menu-btn.active,
+        .header-admin .menu-btn:hover {
+          background: #ffd972;
+          color: #256d54;
+        }
+
+        @media (max-width:700px) {
+          .container {
+            padding:10px;
+            margin:69px auto 40px auto;
+          }
+
+          .table-posts th,
+          .table-posts td {
+            font-size:0.98em;
+          }
+
+          .header-admin {
+            font-size: 1.07rem;
+            height: 49px;
+            border-radius: 0 0 16px 16px;
+            padding: 0 2vw;
+            gap: 10px;
+          }
+
+          .header-admin .menu-toggle {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+          }
+
+          .header-admin .menu-container {
+            display: none;
+            position: absolute;
+            top: 100%;
+            left: 0;
+            right: 0;
+            padding: 12px 2vw 16px 2vw;
+            background: #256d54;
+            box-shadow: 0 6px 30px #256d5412, 0 2px 10px #1d9a7718;
+            border-radius: 0 0 16px 16px;
+          }
+
+          .header-admin .menu-horizontal {
+            display: none;
+            flex-direction: column;
+            gap: 6px;
+          }
+
+          .header-admin .menu-btn {
+            text-align: left;
+            padding: 10px 12px;
+          }
+
+          .header-admin.is-open .menu-container {
+            display: block;
+          }
+
+          .header-admin.is-open .menu-horizontal {
+            display: flex;
+          }
+        }
 
     </style>
 </head>
 <body> 
 <div class="header-admin">
-  <div>Painel da Terapeuta</div>
-  <div class="menu-horizontal">
-    <a class="menu-btn" href="agenda.php">Agenda</a>
-    <a class="menu-btn" href="pacientes.php">Pacientes</a>
-    <a class="menu-btn" href="precos.php">Preços</a>
-    <a class="menu-btn active" href="blog.php">Blog</a>
-    <a class="menu-btn" href="index.php">Home</a>
+  <div class="header-brand">Painel da Terapeuta</div>
+  <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="admin-menu">☰</button>
+  <div class="menu-container">
+    <div class="menu-horizontal" id="admin-menu">
+      <a class="menu-btn" href="agenda.php">Agenda</a>
+      <a class="menu-btn" href="pacientes.php">Pacientes</a>
+      <a class="menu-btn" href="precos.php">Preços</a>
+      <a class="menu-btn active" href="blog.php">Blog</a>
+      <a class="menu-btn" href="index.php">Home</a>
+    </div>
   </div>
 </div>
 <div class="container">
@@ -320,6 +447,34 @@ if (isset($_POST['edit_id'])):
       document.getElementById('conteudo-edit').value = quillEdit.root.innerHTML;
     };
   }
-</script>
-</body>
-</html>
+  </script>
+  <script>
+    (function () {
+      const header = document.querySelector('.header-admin');
+      if (!header) return;
+
+      const toggle = header.querySelector('.menu-toggle');
+      const menuLinks = header.querySelectorAll('.menu-horizontal a');
+      if (!toggle) return;
+
+      const closeMenu = () => {
+        header.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded', 'false');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = header.classList.toggle('is-open');
+        toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+      });
+
+      menuLinks.forEach((link) => {
+        link.addEventListener('click', () => {
+          if (header.classList.contains('is-open')) {
+            closeMenu();
+          }
+        });
+      });
+    })();
+  </script>
+  </body>
+  </html>

--- a/admin/pacientes.php
+++ b/admin/pacientes.php
@@ -60,7 +60,7 @@ $stmt->close();
 <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
 <style>
   body { font-family: Roboto, Arial, sans-serif; background: #fcfaf7; margin:0; }
-  .container { max-width:980px; margin:38px auto 0 auto; background:#fff; border-radius:18px; box-shadow:0 2px 32px #0001; padding:38px 3vw 44px 3vw; }
+  .container { max-width:980px; margin:90px auto 0 auto; background:#fff; border-radius:18px; box-shadow:0 2px 32px #0001; padding:38px 3vw 44px 3vw; }
   h1 { color:#57643a; font-size:2.1rem; font-family:Playfair Display,serif; }
   .table-pacientes { width:100%; border-collapse:collapse; margin-top:32px; }
   .table-pacientes th,.table-pacientes td { border-bottom:1px solid #ece3d3; padding:13px 7px; text-align:left; }
@@ -68,23 +68,146 @@ $stmt->close();
   .table-pacientes tr:hover { background:#f6f4ee; }
   .btn-ver { background:#6A5036; color:#fff; border-radius:8px; border:none; font-size:1rem; font-weight:700; padding:7px 18px; cursor:pointer; transition:background .16s; }
   .btn-ver:hover { background:#8b6f4e; }
-  .header-admin { position: fixed; top: 0; left: 0; right: 0; height: 63px; display: flex; align-items: center; justify-content: space-between; background: #256d54; color: #fff; font-family: 'Playfair Display', serif; font-size: 1.27rem; box-shadow: 0 6px 30px #256d5412, 0 2px 10px #1d9a7718; z-index: 999; padding: 0 4vw; }
-.header-admin .menu-horizontal { display: flex; gap: 14px; }
-.header-admin .menu-btn { background: none; border: none; color: #fff; font-size: 1.09rem; font-weight: 600; padding: 8px 17px 7px 17px; border-radius: 12px; transition: background .17s, color .14s; cursor: pointer; text-decoration: none; outline: none; display: inline-block; }
-.header-admin .menu-btn.active, .header-admin .menu-btn:hover { background: #ffd972; color: #256d54; }
+  .header-admin {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 63px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: #256d54;
+    color: #fff;
+    font-family: 'Playfair Display', serif;
+    font-size: 1.27rem;
+    box-shadow: 0 6px 30px #256d5412, 0 2px 10px #1d9a7718;
+    z-index: 999;
+    padding: 0 4vw;
+    gap: 16px;
+  }
+
+  .header-admin .header-brand {
+    font-weight: 700;
+    letter-spacing: .4px;
+  }
+
+  .header-admin .menu-container {
+    display: flex;
+    align-items: center;
+  }
+
+  .header-admin .menu-horizontal {
+    display: flex;
+    gap: 14px;
+  }
+
+  .header-admin .menu-toggle {
+    display: none;
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 1.7rem;
+    cursor: pointer;
+    line-height: 1;
+    padding: 6px 10px;
+    border-radius: 10px;
+    transition: background .17s;
+  }
+
+  .header-admin .menu-toggle:hover,
+  .header-admin.is-open .menu-toggle {
+    background: rgba(255, 255, 255, 0.12);
+  }
+
+  .header-admin .menu-btn {
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 1.09rem;
+    font-weight: 600;
+    padding: 8px 17px 7px 17px;
+    border-radius: 12px;
+    transition: background .17s, color .14s;
+    cursor: pointer;
+    text-decoration: none;
+    outline: none;
+    display: inline-block;
+  }
+
+  .header-admin .menu-btn.active,
+  .header-admin .menu-btn:hover {
+    background: #ffd972;
+    color: #256d54;
+  }
+
+  @media (max-width: 700px) {
+    .container {
+      margin: 69px auto 0 auto;
+      padding: 24px 3vw 44px 3vw;
+    }
+
+    .header-admin {
+      font-size: 1.07rem;
+      height: 49px;
+      border-radius: 0 0 16px 16px;
+      padding: 0 2vw;
+      gap: 10px;
+    }
+
+    .header-admin .menu-toggle {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .header-admin .menu-container {
+      display: none;
+      position: absolute;
+      top: 100%;
+      left: 0;
+      right: 0;
+      padding: 12px 2vw 16px 2vw;
+      background: #256d54;
+      box-shadow: 0 6px 30px #256d5412, 0 2px 10px #1d9a7718;
+      border-radius: 0 0 16px 16px;
+    }
+
+    .header-admin .menu-horizontal {
+      display: none;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .header-admin .menu-btn {
+      text-align: left;
+      padding: 10px 12px;
+    }
+
+    .header-admin.is-open .menu-container {
+      display: block;
+    }
+
+    .header-admin.is-open .menu-horizontal {
+      display: flex;
+    }
+  }
 </style>
 </head>
 <body>
-    <div class="header-admin">
-  <div>Painel da Terapeuta</div>
-  <div class="menu-horizontal">
-    <a class="menu-btn" href="agenda.php">Agenda</a>
-    <a class="menu-btn active" href="pacientes.php">Pacientes</a>
-    <a class="menu-btn" href="precos.php">Preços</a>
-    <a class="menu-btn" href="blog.php">Blog</a>
-    <a class="menu-btn" href="index.php">Home</a>
+  <div class="header-admin">
+    <div class="header-brand">Painel da Terapeuta</div>
+    <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="admin-menu">☰</button>
+    <div class="menu-container">
+      <div class="menu-horizontal" id="admin-menu">
+        <a class="menu-btn" href="agenda.php">Agenda</a>
+        <a class="menu-btn active" href="pacientes.php">Pacientes</a>
+        <a class="menu-btn" href="precos.php">Preços</a>
+        <a class="menu-btn" href="blog.php">Blog</a>
+        <a class="menu-btn" href="index.php">Home</a>
+      </div>
+    </div>
   </div>
-</div>
 <div class='container'>
   <h1>Pacientes</h1>
   <form method="get" class="filtro-pacientes" style="display:flex; flex-wrap:wrap; gap:12px; margin:18px 0 4px 0; align-items:center;">
@@ -118,5 +241,33 @@ $stmt->close();
     <?php } ?>
   </table>
 </div>
+  <script>
+    (function () {
+      const header = document.querySelector('.header-admin');
+      if (!header) return;
+
+      const toggle = header.querySelector('.menu-toggle');
+      const menuLinks = header.querySelectorAll('.menu-horizontal a');
+      if (!toggle) return;
+
+      const closeMenu = () => {
+        header.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded', 'false');
+      };
+
+      toggle.addEventListener('click', () => {
+        const isOpen = header.classList.toggle('is-open');
+        toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+      });
+
+      menuLinks.forEach((link) => {
+        link.addEventListener('click', () => {
+          if (header.classList.contains('is-open')) {
+            closeMenu();
+          }
+        });
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/admin/precos.php
+++ b/admin/precos.php
@@ -94,7 +94,7 @@ while ($row = $res->fetch_assoc()) {
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
     <style>
         body { font-family: Arial, sans-serif; background: #faf8f2; }
-        .container { max-width: 600px; background: #fff; margin: 44px auto; border-radius: 16px; box-shadow: 0 4px 24px #b7b7b74a; padding: 36px 36px 30px 36px; }
+        .container { max-width: 600px; background: #fff; margin: 94px auto 44px auto; border-radius: 16px; box-shadow: 0 4px 24px #b7b7b74a; padding: 36px 36px 30px 36px; }
         h1 { color: #57643a; font-size: 2rem; margin-bottom: 27px; text-align:center; }
         .form-row { margin-bottom: 22px; display: flex; gap: 24px; align-items: center; }
         .form-row label { flex: 0 0 220px; font-weight: 600; color: #4a4a36; font-size: 1.07em; }
@@ -104,21 +104,144 @@ while ($row = $res->fetch_assoc()) {
         .btn:hover { background: #324a1d; }
         .msg-ok { color: #37692e; text-align: center; margin-bottom: 20px; font-weight: 600; font-size:1.04em; }
         @media(max-width:600px){ .container{padding:20px;} .form-row label{font-size:1em;} }
-        .header-admin { position: fixed; top: 0; left: 0; right: 0; height: 63px; display: flex; align-items: center; justify-content: space-between; background: #256d54; color: #fff; font-family: 'Playfair Display', serif; font-size: 1.27rem; box-shadow: 0 6px 30px #256d5412, 0 2px 10px #1d9a7718; z-index: 999; padding: 0 4vw; }
-        .header-admin .menu-horizontal { display: flex; gap: 14px; }
-        .header-admin .menu-btn { background: none; border: none; color: #fff; font-size: 1.09rem; font-weight: 600; padding: 8px 17px 7px 17px; border-radius: 12px; transition: background .17s, color .14s; cursor: pointer; text-decoration: none; outline: none; display: inline-block; }
-        .header-admin .menu-btn.active, .header-admin .menu-btn:hover { background: #ffd972; color: #256d54; }
+        .header-admin {
+          position: fixed;
+          top: 0;
+          left: 0;
+          right: 0;
+          height: 63px;
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          background: #256d54;
+          color: #fff;
+          font-family: 'Playfair Display', serif;
+          font-size: 1.27rem;
+          box-shadow: 0 6px 30px #256d5412, 0 2px 10px #1d9a7718;
+          z-index: 999;
+          padding: 0 4vw;
+          gap: 16px;
+        }
+
+        .header-admin .header-brand {
+          font-weight: 700;
+          letter-spacing: .4px;
+        }
+
+        .header-admin .menu-container {
+          display: flex;
+          align-items: center;
+        }
+
+        .header-admin .menu-horizontal {
+          display: flex;
+          gap: 14px;
+        }
+
+        .header-admin .menu-toggle {
+          display: none;
+          background: none;
+          border: none;
+          color: #fff;
+          font-size: 1.7rem;
+          cursor: pointer;
+          line-height: 1;
+          padding: 6px 10px;
+          border-radius: 10px;
+          transition: background .17s;
+        }
+
+        .header-admin .menu-toggle:hover,
+        .header-admin.is-open .menu-toggle {
+          background: rgba(255, 255, 255, 0.12);
+        }
+
+        .header-admin .menu-btn {
+          background: none;
+          border: none;
+          color: #fff;
+          font-size: 1.09rem;
+          font-weight: 600;
+          padding: 8px 17px 7px 17px;
+          border-radius: 12px;
+          transition: background .17s, color .14s;
+          cursor: pointer;
+          text-decoration: none;
+          outline: none;
+          display: inline-block;
+        }
+
+        .header-admin .menu-btn.active,
+        .header-admin .menu-btn:hover {
+          background: #ffd972;
+          color: #256d54;
+        }
+
+        @media (max-width: 700px) {
+          .container {
+            margin: 69px auto 24px auto;
+            padding: 32px 24px;
+          }
+
+          .header-admin {
+            font-size: 1.07rem;
+            height: 49px;
+            border-radius: 0 0 16px 16px;
+            padding: 0 2vw;
+            gap: 10px;
+          }
+
+          .header-admin .menu-toggle {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+          }
+
+          .header-admin .menu-container {
+            display: none;
+            position: absolute;
+            top: 100%;
+            left: 0;
+            right: 0;
+            padding: 12px 2vw 16px 2vw;
+            background: #256d54;
+            box-shadow: 0 6px 30px #256d5412, 0 2px 10px #1d9a7718;
+            border-radius: 0 0 16px 16px;
+          }
+
+          .header-admin .menu-horizontal {
+            display: none;
+            flex-direction: column;
+            gap: 6px;
+          }
+
+          .header-admin .menu-btn {
+            text-align: left;
+            padding: 10px 12px;
+          }
+
+          .header-admin.is-open .menu-container {
+            display: block;
+          }
+
+          .header-admin.is-open .menu-horizontal {
+            display: flex;
+          }
+        }
     </style>
 </head>
 <body>
     <div class="header-admin">
-      <div>Painel da Terapeuta</div>
-      <div class="menu-horizontal">
-        <a class="menu-btn" href="agenda.php">Agenda</a>
-        <a class="menu-btn" href="pacientes.php">Pacientes</a>
-        <a class="menu-btn active" href="precos.php">Preços</a>
-        <a class="menu-btn" href="blog.php">Blog</a>
-        <a class="menu-btn" href="index.php">Home</a>
+      <div class="header-brand">Painel da Terapeuta</div>
+      <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="admin-menu">☰</button>
+      <div class="menu-container">
+        <div class="menu-horizontal" id="admin-menu">
+          <a class="menu-btn" href="agenda.php">Agenda</a>
+          <a class="menu-btn" href="pacientes.php">Pacientes</a>
+          <a class="menu-btn active" href="precos.php">Preços</a>
+          <a class="menu-btn" href="blog.php">Blog</a>
+          <a class="menu-btn" href="index.php">Home</a>
+        </div>
       </div>
     </div>
     <div class="container">
@@ -162,6 +285,34 @@ while ($row = $res->fetch_assoc()) {
             </div>
         </form>
     </div>
+    <script>
+      (function () {
+        const header = document.querySelector('.header-admin');
+        if (!header) return;
+
+        const toggle = header.querySelector('.menu-toggle');
+        const menuLinks = header.querySelectorAll('.menu-horizontal a');
+        if (!toggle) return;
+
+        const closeMenu = () => {
+          header.classList.remove('is-open');
+          toggle.setAttribute('aria-expanded', 'false');
+        };
+
+        toggle.addEventListener('click', () => {
+          const isOpen = header.classList.toggle('is-open');
+          toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        });
+
+        menuLinks.forEach((link) => {
+          link.addEventListener('click', () => {
+            if (header.classList.contains('is-open')) {
+              closeMenu();
+            }
+          });
+        });
+      })();
+    </script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- atualiza o CSS das páginas Pacientes, Preços e Blog para reutilizar o cabeçalho responsivo da Agenda
- ajusta o HTML dos cabeçalhos adicionando botão de menu e estado ativo consistente
- replica o script de toggle do menu para fechar/abrir em dispositivos móveis

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e608b83a88832990250ff306548b4c