### PR TITLE
Add viewport metadata to admin pages

### DIFF
--- a/admin/blog.php
+++ b/admin/blog.php
@@ -104,6 +104,7 @@ function categoria_sel($cat, $valor) {
 <head>
       <link rel="icon" type="image/png" href="/favicon-transparente.png">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Painel Blog - Admin</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
     <style>

--- a/admin/pacientes.php
+++ b/admin/pacientes.php
@@ -56,6 +56,7 @@ $stmt->close();
 <head>
       <link rel="icon" type="image/png" href="/favicon-transparente.png">
 <meta charset='UTF-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
 <title>Painel Admin - Pacientes</title>
 <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
 <style>

--- a/admin/precos.php
+++ b/admin/precos.php
@@ -90,6 +90,7 @@ while ($row = $res->fetch_assoc()) {
 <head>
       <link rel="icon" type="image/png" href="/favicon-transparente.png">
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Painel de Preços - Admin</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
     <style>


### PR DESCRIPTION
## Summary
- add a responsive viewport meta tag to the admin pacientes, blog, and precos pages so the header layout can collapse on smaller screens

## Testing
- not run (requires authenticated admin session to validate the responsive header)

------
https://chatgpt.com/codex/tasks/task_e_68e60c65c3308329823a7c666df2010d